### PR TITLE
rewrote readFile, added rusfmt::skip macros and handled one error

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "sysutil"
-version = "0.2.1"
+version = "0.2.3"


### PR DESCRIPTION
made readFile more readable with early returns, added rustfmt::skip macros to stop rustfmt from formatting certain parts of code and handled error with temperatures not existing